### PR TITLE
Correção do card dos professores: layout fix, altura uniforme

### DIFF
--- a/frontend/src/pages/ProfessoresPage.jsx
+++ b/frontend/src/pages/ProfessoresPage.jsx
@@ -26,7 +26,7 @@ export default function ProfessoresPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalProfessores, setTotalProfessores] = useState(0);
-  const ITEMS_PER_PAGE = 20;
+  const ITEMS_PER_PAGE = 21;
 
   const pageBg = useColorModeValue("gray.50", "gray.900");
   const headerBg = useColorModeValue("white", "gray.800");
@@ -195,11 +195,13 @@ export default function ProfessoresPage() {
               columns={{ base: 1, md: 2, lg: 3, xl: 3 }}
               spacing={6}
               pb={10}
+              sx={{ gridAutoRows: "1fr" }}   
             >
               {currentProfessors.map((professor) => (
-                <ProfessorCard key={professor.id} professor={professor} />
+              <ProfessorCard key={professor.id} professor={professor} />
               ))}
             </SimpleGrid>
+
 
             {totalPages > 1 && (
                 <HStack justify="center" spacing={4} py={8}>


### PR DESCRIPTION
✔️ O que foi feito

Ajuste completo do card dos professores

Remoção de telefone e endereço

Remoção do resumo do professor

Layout mais limpo e padronizado

Alturas dos cards igualadas usando h="100%"

Avatar maior e com mais presença

Ajustes visuais em espaçamento, divisores e hierarquia

Componente compatível com dados reais da API (áreas de interesse, campus, e-mail, Lattes)

✔️ Motivação

O card estava quebrando com dados reais da API, exibindo informações desnecessárias e com alturas diferentes. Agora o layout está consistente e pronto para produção.

✔️ Como testar

Acessar /professores

Conferir cards lado a lado

Verificar que todos têm a mesma altura

Conferir que apenas e-mail, campus, Lattes e áreas de interesse aparecem